### PR TITLE
Ruby 3.1+ / Psych 4+ compatibility

### DIFF
--- a/lib/migration_signature/config.rb
+++ b/lib/migration_signature/config.rb
@@ -14,7 +14,11 @@ module MigrationSignature
       return new(DEFAULTS) unless File.exist?(CONFIG_FILE_PATH)
 
       require 'yaml'
-      hash = YAML.safe_load(File.read(CONFIG_FILE_PATH), [Regexp]) || {}
+      hash = if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("4.0.0")
+        YAML.safe_load(File.read(CONFIG_FILE_PATH), permitted_classes: [Regexp])
+      else
+        YAML.safe_load(File.read(CONFIG_FILE_PATH), [Regexp])
+      end || {}
 
       new(DEFAULTS.merge(hash))
     end


### PR DESCRIPTION
Arguments for `Psych.safe_load` and therefore `YAML.safe_load` were changed in psych 4.0.0 https://github.com/ruby/psych/pull/487