### PR TITLE
Remove build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,6 @@ Or install it yourself as:
 gem install migration_signature
 ```
 
-To build signatures for all existing migrations, run the following:
-
-```bash
-bundle exec migration_signature buildall
-```
-
 ## Usage
 
 Migration signatures will automatically be prepended to migration files when 

--- a/exe/migration_signature
+++ b/exe/migration_signature
@@ -6,11 +6,9 @@ require 'optparse'
 
 OptionParser.new do |parser|
   parser.banner = <<~BANNER
-    Usage: migration_signature {check|buildall|build <file>}
+    Usage: migration_signature {check}
 
         check        - Check all your migration files for present and correct migration signatures
-        buildall     - Rebuild all migration signatures for all files (should only be used in setup)
-        build <file> - Rebuild a migration signature for a single migration
 
   BANNER
 
@@ -22,7 +20,7 @@ end.parse!
 
 action = ARGV[0]
 unless action
-  warn 'You must supply one of {check|buildall|build <file>}'
+  warn 'You must supply one of {check}'
   exit 1
 end
 
@@ -33,18 +31,7 @@ if action == 'check'
     warn e.message
     exit 1
   end
-elsif action == 'buildall'
-  MigrationSignature.build_all
-elsif action == 'build'
-  file = ARGV[1]
-
-  unless file
-    warn 'You must supply a file to build a signature for'
-    exit 1
-  end
-
-  MigrationSignature.build_file(file)
 else
-  warn 'You must supply one of {check|buildall|build <file>}'
+  warn 'You must supply one of {check}'
   exit 1
 end

--- a/lib/migration_signature.rb
+++ b/lib/migration_signature.rb
@@ -21,12 +21,6 @@ module MigrationSignature
     true
   end
 
-  def self.build_all
-    config.all_runnable_files.each do |path|
-      MigrationSignature::MigrationFile.new(path).update_signature!
-    end
-  end
-
   def self.build_file(file)
     mf = MigrationSignature::MigrationFile.new(file)
 

--- a/lib/migration_signature/version.rb
+++ b/lib/migration_signature/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MigrationSignature
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
These led to an anti-pattern where folks would remove a migration signature from a file, and then build it, after changing a migration. The point of this gem is to discourage that.